### PR TITLE
Adds Go version checking to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,25 @@ BUILD_FLAGS := -ldflags '$(ldflags)'
 
 all: install
 
-build: go.sum
+build: check-go-version go.sum
 ifeq ($(OS), Windows_NT)
 	go build -mod=readonly $(BUILD_FLAGS) -o build/$(shell go env GOOS)/decentrd.exe ./cmd/decentrd
 else
 	go build -mod=readonly $(BUILD_FLAGS) -o build/$(shell go env GOOS)/decentrd ./cmd/decentrd
 endif
 
-install: go.sum
+install: check-go-version go.sum
 	go install -mod=readonly $(BUILD_FLAGS) ./cmd/decentrd
 
-linux: go.sum
+linux: check-go-version go.sum
 	GOOS=linux GOARCH=amd64 $(MAKE) build
+
+# Add check to make sure we are using the proper Go version before proceeding with anything
+check-go-version:
+	@if ! go version | grep -q "go1.19"; then \
+		echo "\033[0;31mERROR:\033[0m Go version 1.19 is required for compiling decentrd. It looks like you are using" "$(shell go version) \nThere are potential consensus-breaking changes that can occur when running binaries compiled with different versions of Go. Please download Go version 1.19 and retry. Thank you!"; \
+		exit 1; \
+	fi
 
 ### tools ###
 
@@ -64,9 +71,9 @@ containerProtoGen=decentr-buildtools-protogen
 containerProtoSwaggerGen=decentr-buildtools-protoswaggergen
 containerProtoFmt=decentr-buildtools-protofmt
 
-proto-all: proto-lint proto-gen
+proto-all: check-go-version proto-lint proto-gen
 
-proto-gen:
+proto-gen: check-go-version
 	@echo "Generating Protobuf files"
 	@if docker ps -a --format '{{.Names}}' | grep -Eq "^${containerProtoGen}$$"; then docker start -a $(containerProtoGen); else docker run --name $(containerProtoGen) -v $(CURDIR):/workspace --workdir /workspace $(buildtools) \
 		sh ./scripts/protocgen.sh; fi


### PR DESCRIPTION
Checks to make sure that Go version 1.19 is being used before compiling. There are potential issues when running binaries compiled with different versions of Go, and this should help minimalize this from happening.